### PR TITLE
🎨 Palette: Add ARIA label to Quick Search button in MobileDrawer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [Added ARIA label to MobileDrawer]
+**Learning:** Icon-only buttons lacking ARIA labels are a recurring accessibility issue.
+**Action:** Always verify icon buttons have ARIA labels in future components.

--- a/frontend/src/components/layout/MobileDrawer.tsx
+++ b/frontend/src/components/layout/MobileDrawer.tsx
@@ -58,6 +58,7 @@ export default function MobileDrawer({
 
         {/* Mobile Quick Search */}
         <button
+          aria-label="Open quick search"
           onClick={() => {
             onClose();
             setCommandMenuOpen(true);


### PR DESCRIPTION
💡 What: Added an `aria-label="Open quick search"` to the Quick Search button in the `MobileDrawer` component.
🎯 Why: To improve accessibility for screen readers on an icon-heavy button, making the UI more inclusive.
♿ Accessibility: Ensures that screen reader users understand the purpose of the Quick Search button.

---
*PR created automatically by Jules for task [4212255552417121633](https://jules.google.com/task/4212255552417121633) started by @pavanbadempet*